### PR TITLE
Introduce proof-of-inference concept

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Coding Guidelines
+
+Please follow the basic Monero contributing guidelines when modifying source files:
+
+- Commit messages should use the format `subdirectory: description`.
+- Keep patches focused on a single problem.
+- Maintain existing code style in touched files.
+- Run `make -j2 release-test` before submitting changes.
+

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Monero is a private, secure, untraceable, decentralised digital currency. You ar
 
 **Decentralization:** The utility of Monero depends on its decentralised peer-to-peer consensus network - anyone should be able to run the monero software, validate the integrity of the blockchain, and participate in all aspects of the monero network using consumer-grade commodity hardware. Decentralization of the monero network is maintained by software development that minimizes the costs of running the monero software and inhibits the proliferation of specialized, non-commodity hardware.
 
+## Proof of Inference
+
+JOY Sovereign Coin experiments with a *proof-of-inference* consensus design. Instead of traditional mining, nodes submit verifiable machine learning inference results to participate in block production. The inference output is hashed and converted to a deterministic numeric score in `src/cryptonote_basic/proof_of_inference.cpp`.
+
 ## About this project
 
 This is the core implementation of Monero. It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of Monero that uses the protocol and network in a compatible manner.

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -50,6 +50,7 @@ set(cryptonote_basic_sources
   cryptonote_basic_impl.cpp
   cryptonote_format_utils.cpp
   difficulty.cpp
+  proof_of_inference.cpp
   hardfork.cpp
   merge_mining.cpp
   miner.cpp)

--- a/src/cryptonote_basic/proof_of_inference.cpp
+++ b/src/cryptonote_basic/proof_of_inference.cpp
@@ -1,0 +1,19 @@
+#include "proof_of_inference.h"
+#include <cstring>
+
+namespace cryptonote
+{
+  uint64_t calculate_inference_score(const std::string &model_output)
+  {
+    // Hash the model output and treat the first 8 bytes as
+    // a little-endian 64-bit score. This deterministic score
+    // can be used for experimental ordering of blocks.
+
+    crypto::hash h = crypto::cn_fast_hash(model_output.data(), model_output.size());
+    uint64_t score = 0;
+    static_assert(sizeof(score) <= sizeof(h.data), "hash too small");
+    std::memcpy(&score, h.data, sizeof(score));
+    return score;
+  }
+}
+

--- a/src/cryptonote_basic/proof_of_inference.h
+++ b/src/cryptonote_basic/proof_of_inference.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+
+#include "crypto/hash.h"
+
+namespace cryptonote
+{
+  /**
+   * \brief Calculate a deterministic score from a model output
+   *
+   * The output is hashed using `cn_fast_hash` and the first eight
+   * bytes of the hash are interpreted as a little-endian 64-bit
+   * value. This score can be used in experimental proof-of-inference
+   * consensus algorithms.
+   */
+  uint64_t calculate_inference_score(const std::string &model_output);
+}
+


### PR DESCRIPTION
## Summary
- add a short section in the README about using a proof-of-inference approach
- implement `calculate_inference_score` using `cn_fast_hash`
- wire `proof_of_inference.cpp` into the `cryptonote_basic` build
- add AGENTS file outlining contribution rules

## Testing
- `make -j2 release-test` *(fails: submodules not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_686811a8ff64832f86c63979bedc45bd