### PR TITLE
Improve proof-of-inference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ Monero is a private, secure, untraceable, decentralised digital currency. You ar
 JOY Sovereign Coin experiments with a *proof-of-inference* consensus design. Instead of traditional mining, nodes submit verifiable machine learning inference results to participate in block production. The inference output is hashed and converted to a deterministic numeric score in `src/cryptonote_basic/proof_of_inference.cpp`.
 These lightweight models can run on edge devices, allowing everyday users to secure the network without dedicated mining hardware. This feature is experimental and disabled by default.
 
+### Obtaining a scoring model
+A reference ONNX model for testing is provided in the [jsc-models](https://github.com/joy-sovereign/jsc-models) repository. Clone the repository and run the included training script:
+```bash
+git clone https://github.com/joy-sovereign/jsc-models.git
+cd jsc-models
+python3 -m pip install -r requirements.txt
+python3 train.py --output model.onnx
+```
+Any ONNX model that produces deterministic output can be used.
+
+### Running inference locally
+Use `utils/run_inference.py` to generate an output for a block hashing blob:
+```bash
+python3 utils/run_inference.py --model model.onnx --input block_blob.bin --out inference.bin
+```
+When `--inference-mining` is enabled, `monerod` computes `calculate_block_inference_score` on each candidate block and compares it to the difficulty target. The script helps verify the score produced by your model.
+
+### Dependencies
+The example tooling requires Python 3 with `numpy` and `onnxruntime` installed:
+```bash
+pip install numpy onnxruntime
+```
+If you build the model yourself you may also need `torch` or another framework.
+
 ## About this project
 
 This is the core implementation of Monero. It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of Monero that uses the protocol and network in a compatible manner.

--- a/utils/run_inference.py
+++ b/utils/run_inference.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run ONNX model to produce proof-of-inference output."""
+
+import argparse
+import numpy as np
+import onnxruntime as ort
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run inference for JSC blocks")
+    parser.add_argument("--model", required=True, help="ONNX model file")
+    parser.add_argument("--input", required=True, help="Binary block blob")
+    parser.add_argument("--out", default="inference.bin", help="Output file")
+    args = parser.parse_args()
+
+    session = ort.InferenceSession(args.model)
+    input_name = session.get_inputs()[0].name
+    data = np.fromfile(args.input, dtype=np.uint8)
+    result = session.run(None, {input_name: data})[0]
+    result.tofile(args.out)
+    print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how to obtain a sample model for proof-of-inference
- show example commands for running local inference
- note Python dependencies
- add helper `run_inference.py` script

## Testing
- `make -j2 release-test` *(fails: Submodule 'external/miniupnp' is not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_68682df17fac832fa8378a20a049515a