### PR TITLE
Update fees doc

### DIFF
--- a/docs/FEES.md
+++ b/docs/FEES.md
@@ -1,0 +1,3 @@
+# Fees Configuration
+
+The build option `CRYPTONOTE_FEES_ENABLED` determines whether the client uses dynamic or static fees. If you change this option, you must recompile the binaries for the new setting to take effect.


### PR DESCRIPTION
## Summary
- document that recompilation is required when changing `CRYPTONOTE_FEES_ENABLED`

## Testing
- `make -j2 release-test` *(fails: Submodule 'external/miniupnp' is not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_686839fb4778832f85745a4b058cb2b9